### PR TITLE
Fix timer closure

### DIFF
--- a/generar_reporte.php
+++ b/generar_reporte.php
@@ -1,6 +1,6 @@
 <?php
-require 'db.php';
-require 'fpdf.php';
+require_once __DIR__.'/db.php';
+require_once __DIR__.'/fpdf.php';
 
 // Limpiar cualquier salida previa para evitar errores al enviar el PDF
 if (ob_get_length()) {
@@ -23,7 +23,7 @@ if (!$data) {
     die('Datos no encontrados');
 }
 
-header('Content-Type: application/pdf');
+// FPDF envía sus propias cabeceras para el PDF
 
 $pdf = new FPDF();
 $pdf->AddPage();

--- a/mantencion.php
+++ b/mantencion.php
@@ -180,6 +180,7 @@ if (!$mantencion_id && !$iniciar) {
     let timerInterval;
 
     function startTimer() {
+        if (timerInterval) clearInterval(timerInterval);
         timerInterval = setInterval(() => {
             let elapsed = Math.floor((Date.now() - startTime) / 1000);
             let h = Math.floor(elapsed / 3600).toString().padStart(2, '0');
@@ -283,11 +284,7 @@ if (!$mantencion_id && !$iniciar) {
     }
 
     document.addEventListener('DOMContentLoaded', startTimer);
-    window.addEventListener('pageshow', function(e) {
-        if (e.persisted) {
-            startTimer();
-        }
-    });
+    window.addEventListener('pageshow', startTimer);
 </script>
 <script src="offline.js"></script>
 </body>

--- a/mantencion.php
+++ b/mantencion.php
@@ -1,7 +1,8 @@
 <?php
 session_start();
-header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
 header('Pragma: no-cache');
+header('Expires: 0');
 include 'db.php';
 
 if (!isset($_SESSION['usuario_id']) || $_SESSION['rol'] !== 'tecnico') {
@@ -286,6 +287,7 @@ if (!$mantencion_id && !$iniciar) {
         if (e.persisted) {
             window.location.reload();
         }
+    });
 </script>
 <script src="offline.js"></script>
 </body>

--- a/mantencion.php
+++ b/mantencion.php
@@ -282,10 +282,10 @@ if (!$mantencion_id && !$iniciar) {
         });
     }
 
-    window.onload = startTimer;
+    document.addEventListener('DOMContentLoaded', startTimer);
     window.addEventListener('pageshow', function(e) {
         if (e.persisted) {
-            window.location.reload();
+            startTimer();
         }
     });
 </script>


### PR DESCRIPTION
## Summary
- prevent caching when viewing `mantencion.php`
- close the pageshow listener so JS executes correctly

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855bbc1fa3883229c3e404039d3ed14